### PR TITLE
Spellcheck of the comments in SeaHash

### DIFF
--- a/seahash/src/buffer.rs
+++ b/seahash/src/buffer.rs
@@ -97,15 +97,15 @@ pub fn hash(buf: &[u8]) -> u64 {
 
 /// Hash some buffer according to a chosen seed.
 ///
-/// The keys are expected to be chosen from an uniform distribution. The keys should be mutually
+/// The keys are expected to be chosen from a uniform distribution. The keys should be mutually
 /// distinct to avoid issues with collisions if the lanes are permuted.
 ///
 /// This is not secure, as [the key can be extracted with a bit of computational
 /// work](https://github.com/ticki/tfs/issues/5), as such, it is recommended to have a fallback
 /// hash function (adaptive hashing) in the case of hash flooding. It can be considered unbroken if
-/// the output are not known (i.e. no malicious party has access to the raw values of the keys,
+/// the output is not known (i.e. no malicious party has access to the raw values of the keys,
 /// only a permutation thereof).), however I absolutely do not recommend using it for this. If you
-/// want to be strict, this should only be used as a layer of obfustication, such that the fallback
+/// want to be strict, this should only be used as a layer of obfuscation, such that the fallback
 /// (e.g. SipHash) is harder to trigger.
 ///
 /// In the future, I might strengthen the security if possible while having backward compatibility

--- a/seahash/src/lib.rs
+++ b/seahash/src/lib.rs
@@ -28,7 +28,7 @@
 //! # A word of warning!
 //!
 //! This is **not** a cryptographic function, and it certainly should not be used as one. If you
-//! want a good cryptograhic hash function, you should use SHA-3 (Keccak) or BLAKE2.
+//! want a good cryptographic hash function, you should use SHA-3 (Keccak) or BLAKE2.
 //!
 //! It is not secure, nor does it aim to be. It aims to have high quality pseudorandom output and
 //! few collisions, as well as being fast.
@@ -103,7 +103,7 @@
 //! # Inner workings
 //!
 //! In technical terms, SeaHash follows a alternating 4-state length-padded Merkle–Damgård
-//! construction with an XOR-diffuse compression function (click to enlargen):
+//! construction with an XOR-diffuse compression function (click to enlarge):
 //!
 //! [![A diagram.](http://ticki.github.io/img/seahash_construction_diagram.svg)]
 //! (http://ticki.github.io/img/seahash_construction_diagram.svg)
@@ -127,10 +127,10 @@
 //! The advantage of having four completely segregated (note that there is no mix round, so they're
 //! entirely independent) states is that fast parallelism is possible. For example, if I were to
 //! hash 1 TB, I can spawn up four threads which can run independently without _any_
-//! intercommunication or syncronization before the last round.
+//! intercommunication or synchronization before the last round.
 //!
 //! If the diffusion function (f) was cryptographically secure, it would pass cryptoanalysis
-//! trivially. This might seem irrelavant, as it clearly isn't cryptographically secure, but it
+//! trivially. This might seem irrelevant, as it clearly isn't cryptographically secure, but it
 //! tells us something about the inner semantics. In particular, any diffusion function with
 //! sufficient statistical quality will make up a good hash function in this construction.
 //!

--- a/seahash/src/reference.rs
+++ b/seahash/src/reference.rs
@@ -16,7 +16,7 @@
 //! If a seed is given, each of the initial state component are modularly multiplied by the seed.
 //!
 //! From the stream, we read one 64-bit block (in little-endian) at a time.  This number, `n`,
-//! determines the new the new state by:
+//! determines the new state by:
 //!
 //! ```notest
 //! a' = b
@@ -25,7 +25,7 @@
 //! d  = g(a ⊕ n)
 //! ```
 //!
-//! `g(x)` is defined as `g(x) = j(h(j(x))))` with `h(x) = (x ≫ 32) ≫ (x ≫ 60)` and `j(x) ≡ px (mod
+//! `g(x)` is defined as `g(x) = j(h(j(x)))` with `h(x) = (x ≫ 32) ≫ (x ≫ 60)` and `j(x) ≡ px (mod
 //! 2^64)` with `p = 0x7ed0e9fa0d94a33`.
 //!
 //! Let the final state be `(x, y, z, w)`. Then the final result is given by `H = g(x ⊕ y ⊕ z ⊕ w ⊕
@@ -123,7 +123,7 @@ pub fn hash_seeded(buf: &[u8], k1: u64, k2: u64, k3: u64, k4: u64) -> u64 {
     // Initialize the state.
     let mut state = State::with_seeds(k1, k2, k3, k4);
 
-    // Partition the rounded down buffer to chunks of 8 bytes, and iterate over them. The last
+    // Partition the rounded down buffer into chunks of 8 bytes, and iterate over them. The last
     // block might not be 8 bytes long.
     for int in buf.chunks(8) {
         // Read the chunk into an integer and write into the state.


### PR DESCRIPTION
While reading the the documentation I found a couple of minor spelling mistakes.